### PR TITLE
feat: application command error logging handler

### DIFF
--- a/src/modules/Hello.ts
+++ b/src/modules/Hello.ts
@@ -8,6 +8,11 @@ class HelloExtension extends Extension {
     await this.commandClient.fetchOwners()
   }
 
+  @listener({ event: 'applicationCommandInvokeError', emitter: 'cts' })
+  async errorHandler(err: Error) {
+    this.logger.error(err)
+  }
+
   @applicationCommand({
     name: "ping",
     type: ApplicationCommandType.ChatInput,


### PR DESCRIPTION
command.ts does not display some fatal errors without a default error handler.
I added a default error handler to the template so that the template user does not experience confusion.

This sample handler is responsible for basic tslog error logging only.